### PR TITLE
Add helper utilities and fix retry

### DIFF
--- a/codehem/core/error_handling.py
+++ b/codehem/core/error_handling.py
@@ -79,8 +79,13 @@ class InvalidParameterError(ValidationError):
 
 class InvalidTypeError(ValidationError):
     """Exception raised when a parameter has an incorrect type."""
-    def __init__(self, parameter: str, value: Any, expected_type: Union[Type, str], **kwargs):
-        expected_type_str = expected_type if isinstance(expected_type, str) else expected_type.__name__
+    def __init__(self, parameter: str, value: Any, expected_type: Union[Type, Tuple[Type, ...], str], **kwargs):
+        if isinstance(expected_type, str):
+            expected_type_str = expected_type
+        elif isinstance(expected_type, tuple):
+            expected_type_str = ', '.join(t.__name__ for t in expected_type)
+        else:
+            expected_type_str = expected_type.__name__
         message = f"Invalid type for parameter '{parameter}': {type(value).__name__}. Expected: {expected_type_str}"
         super().__init__(message, parameter=parameter, value=value, expected=expected_type_str, **kwargs)
 

--- a/codehem/core/error_utilities/__init__.py
+++ b/codehem/core/error_utilities/__init__.py
@@ -12,8 +12,36 @@ from .formatting import format_user_friendly_error, format_error_message, format
 from .formatting import with_friendly_errors
 
 # Import and re-export retry mechanisms
-from .retry import linear_backoff, exponential_backoff, jittered_backoff
-from .retry import retry, retry_with_backoff
+from .retry import (
+    linear_backoff,
+    exponential_backoff,
+    jittered_backoff,
+    retry,
+    retry_with_backoff,
+    retry_exponential,
+    retry_jittered,
+    can_retry,
+    retry_if_exception_type,
+    retry_if_exception_message,
+    retry_if_result_none,
+)
+
+# Import logging and graceful utilities
+from .helpers import (
+    ErrorLogFormatter,
+    ErrorLogger,
+    log_error,
+    log_errors,
+    CircuitBreaker,
+    CircuitBreakerError,
+    fallback,
+    FeatureFlags,
+    with_feature_flag,
+    ExceptionMapper,
+    convert_exception,
+    map_exception,
+    catching,
+)
 
 # Import and re-export batch processing utilities
 from .batch import ErrorCollection, BatchOperationError

--- a/codehem/core/error_utilities/helpers.py
+++ b/codehem/core/error_utilities/helpers.py
@@ -1,0 +1,267 @@
+"""Utility classes and decorators used in tests.
+
+This module provides simplified implementations of several helper
+constructs that were available in earlier versions of CodeHem.
+They are sufficient for the unit tests in this repository.
+"""
+from __future__ import annotations
+
+import functools
+import logging
+import time
+from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar
+
+from codehem.core.error_handling import CodeHemError, ValidationError
+
+T = TypeVar("T")
+
+
+# ===== Logging utilities =====
+class ErrorLogFormatter:
+    """Utility for formatting exceptions."""
+
+    @staticmethod
+    def format_basic(error: Exception) -> str:
+        return f"{type(error).__name__}: {error}"
+
+    @staticmethod
+    def format_with_context(error: Exception) -> str:
+        if isinstance(error, CodeHemError) and getattr(error, "context", None):
+            ctx = ", ".join(f"{k}={v}" for k, v in error.context.items())
+            return f"{type(error).__name__}: {error.message} [{ctx}]"
+        return ErrorLogFormatter.format_basic(error)
+
+    @staticmethod
+    def format_with_trace(error: Exception, limit: int = 10) -> str:
+        if not getattr(error, "__traceback__", None):
+            return ErrorLogFormatter.format_with_context(error)
+        import traceback
+
+        tb = "".join(traceback.format_tb(error.__traceback__, limit=limit))
+        return f"{ErrorLogFormatter.format_with_context(error)}\n\nTraceback:\n{tb}"
+
+
+class ErrorLogger:
+    """Small wrapper around :mod:`logging` used in tests."""
+
+    def __init__(self, logger_name: str = "codehem") -> None:
+        self.logger = logging.getLogger(logger_name)
+
+    def _log(self, level: int, message: str, error: Optional[Exception], include_trace: bool) -> None:
+        if error:
+            if include_trace:
+                message = f"{message}\n{ErrorLogFormatter.format_with_trace(error)}"
+            else:
+                message = f"{message}: {ErrorLogFormatter.format_with_context(error)}"
+        self.logger.log(level, message)
+
+    def debug(self, message: str, error: Optional[Exception] = None, include_trace: bool = False) -> None:
+        self._log(logging.DEBUG, message, error, include_trace)
+
+    def info(self, message: str, error: Optional[Exception] = None) -> None:
+        self._log(logging.INFO, message, error, False)
+
+    def warning(self, message: str, error: Optional[Exception] = None, include_trace: bool = False) -> None:
+        self._log(logging.WARNING, message, error, include_trace)
+
+    def error(self, message: str, error: Optional[Exception] = None, include_trace: bool = True) -> None:
+        self._log(logging.ERROR, message, error, include_trace)
+
+    def critical(self, message: str, error: Optional[Exception] = None, include_trace: bool = True) -> None:
+        self._log(logging.CRITICAL, message, error, include_trace)
+
+    def log_exception(self, error: Exception, level: int = logging.ERROR, message: Optional[str] = None, include_trace: bool = True) -> None:
+        self._log(level, message or str(error), error, include_trace)
+
+
+error_logger = ErrorLogger()
+
+
+def log_error(message: str, error: Optional[Exception] = None, level: int = logging.ERROR, include_trace: bool = True, logger: Optional[logging.Logger] = None) -> None:
+    custom = ErrorLogger(logger.name) if logger else error_logger
+    custom.log_exception(error, level, message, include_trace) if error else custom.debug(message)
+
+
+def log_errors(func: Callable[..., T]) -> Callable[..., T]:
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            log_error(f"Error in {func.__name__}", e, logging.ERROR, True)
+            raise
+
+    return wrapper
+
+
+# ===== Graceful degradation utilities =====
+class CircuitBreakerError(Exception):
+    """Raised when a circuit breaker blocks execution."""
+
+
+class CircuitBreaker:
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half-open"
+
+    def __init__(self, failure_threshold: int = 5, recovery_timeout: float = 30.0) -> None:
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self._state = self.CLOSED
+        self.failure_count = 0
+        self.last_failure_time = 0.0
+
+    @property
+    def state(self) -> str:
+        if self._state == self.OPEN and (time.time() - self.last_failure_time >= self.recovery_timeout):
+            self._state = self.HALF_OPEN
+        return self._state
+
+    def execute(self, func: Callable[[], T]) -> T:
+        if self.state == self.OPEN:
+            raise CircuitBreakerError("Circuit open")
+        try:
+            result = func()
+        except Exception:
+            self.failure_count += 1
+            self.last_failure_time = time.time()
+            if self.failure_count >= self.failure_threshold:
+                self._state = self.OPEN
+            raise
+        else:
+            if self.state == self.HALF_OPEN:
+                self.reset()
+            return result
+
+    def reset(self) -> None:
+        self._state = self.CLOSED
+        self.failure_count = 0
+        self.last_failure_time = 0.0
+
+
+def fallback(backup_function: Callable[..., T], exceptions: Tuple[Type[Exception], ...] = (Exception,), log_errors: bool = True, logger: Optional[logging.Logger] = None) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            try:
+                return func(*args, **kwargs)
+            except exceptions as e:
+                if log_errors:
+                    log_error(f"Function {func.__name__} failed", e, logging.WARNING, True, logger)
+                return backup_function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+class FeatureFlags:
+    def __init__(self) -> None:
+        self._flags: Dict[str, bool] = {}
+        self._defaults: Dict[str, bool] = {}
+
+    def register(self, flag_name: str, default_value: bool = True) -> None:
+        self._defaults[flag_name] = default_value
+        self._flags.setdefault(flag_name, default_value)
+
+    def enable(self, flag_name: str) -> None:
+        self._flags[flag_name] = True
+
+    def disable(self, flag_name: str) -> None:
+        self._flags[flag_name] = False
+
+    def is_enabled(self, flag_name: str) -> bool:
+        return self._flags.get(flag_name, self._defaults.get(flag_name, False))
+
+    def reset_all(self) -> None:
+        for k, v in self._defaults.items():
+            self._flags[k] = v
+
+
+feature_flags = FeatureFlags()
+
+
+def with_feature_flag(flag_name: str, default_behavior: bool = True) -> Callable[[Callable[..., T]], Callable[..., Optional[T]]]:
+    def decorator(func: Callable[..., T]) -> Callable[..., Optional[T]]:
+        feature_flags.register(flag_name, default_behavior)
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Optional[T]:
+            if feature_flags.is_enabled(flag_name):
+                return func(*args, **kwargs)
+            return kwargs.pop("fallback_value", None)
+
+        return wrapper
+
+    return decorator
+
+
+# ===== Exception conversion utilities =====
+class ExceptionMapper:
+    def __init__(self) -> None:
+        self._mapping: Dict[Type[Exception], Tuple[Type[Exception], Optional[str], Dict[str, str]]] = {}
+
+    def register(self, source_exception: Type[Exception], target_exception: Type[Exception], message_template: Optional[str] = None, context_mapping: Optional[Dict[str, str]] = None) -> None:
+        self._mapping[source_exception] = (target_exception, message_template, context_mapping or {})
+
+    def convert(self, exception: Exception) -> Exception:
+        exc_type = type(exception)
+        for source, (target, template, context_map) in self._mapping.items():
+            if isinstance(exception, source):
+                message = template.format(original=str(exception)) if template else str(exception)
+                if issubclass(target, CodeHemError):
+                    context = {k: getattr(exception, src, None) for src, k in context_map.items()}
+                    return target(message, **context)
+                return target(message)
+        return exception
+
+    def wrap(self, func: Callable[..., T], *source_exceptions: Type[Exception]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:
+                if source_exceptions and not isinstance(e, source_exceptions):
+                    raise
+                converted = self.convert(e)
+                if converted is e:
+                    raise
+                raise converted from e
+
+        return wrapper
+
+
+def convert_exception(exception: Exception, target_exception: Type[Exception], message: Optional[str] = None, **context: Any) -> Exception:
+    msg = message or str(exception)
+    if issubclass(target_exception, CodeHemError):
+        new_exc = target_exception(msg, **context)
+    else:
+        new_exc = target_exception(msg)
+    new_exc.__cause__ = exception
+    return new_exc
+
+
+def map_exception(source_exception: Type[Exception], target_exception: Type[Exception], message_template: Optional[str] = None, context_mapping: Optional[Dict[str, str]] = None) -> None:
+    global _default_mapper
+    _default_mapper.register(source_exception, target_exception, message_template, context_mapping)
+
+
+_default_mapper = ExceptionMapper()
+
+
+def catching(*exception_types: Type[Exception], reraise_as: Optional[Type[Exception]] = None) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            try:
+                return func(*args, **kwargs)
+            except exception_types as e:
+                if reraise_as is not None:
+                    converted = convert_exception(e, reraise_as, f"Error in {func.__name__}")
+                    raise converted from e
+                raise
+
+        return wrapper
+
+    return decorator
+

--- a/codehem/core/error_utilities/retry.py
+++ b/codehem/core/error_utilities/retry.py
@@ -11,7 +11,6 @@ import time
 import re
 from typing import Any, Callable, List, Optional, Tuple, Type, TypeVar, Union
 
-from codehem.core.error_context import error_context
 
 # Type variables
 T = TypeVar('T')
@@ -132,25 +131,21 @@ def retry(max_attempts: int = DEFAULT_MAX_RETRIES,
             
             while attempt <= max_attempts:
                 try:
-                    with error_context("retry", 
-                                      operation=func.__name__, 
-                                      attempt=attempt, 
-                                      max_attempts=max_attempts):
-                        return func(*args, **kwargs)
+                    return func(*args, **kwargs)
                 except exceptions as e:
                     last_exception = e
-                    
+
                     if logger:
                         logger.warning(
                             f"Attempt {attempt}/{max_attempts} failed for {func.__name__}: {str(e)}"
                         )
-                    
+
                     attempt += 1
-                    
-                    # If this was the last attempt, don't log about retrying
-                    if attempt <= max_attempts:
-                        if logger:
-                            logger.info(f"Retrying {func.__name__} (attempt {attempt}/{max_attempts})...")
+
+                    if attempt <= max_attempts and logger:
+                        logger.info(
+                            f"Retrying {func.__name__} (attempt {attempt}/{max_attempts})..."
+                        )
             
             # If we get here, all attempts failed
             if logger:
@@ -209,11 +204,7 @@ def retry_with_backoff(
             
             while attempt <= max_attempts:
                 try:
-                    with error_context("retry", 
-                                      operation=func.__name__, 
-                                      attempt=attempt, 
-                                      max_attempts=max_attempts):
-                        return func(*args, **kwargs)
+                    return func(*args, **kwargs)
                 except exceptions as e:
                     last_exception = e
                     
@@ -377,11 +368,7 @@ def can_retry(
             
             while attempt <= max_attempts:
                 try:
-                    with error_context("retry", 
-                                      operation=func.__name__, 
-                                      attempt=attempt, 
-                                      max_attempts=max_attempts):
-                        result = func(*args, **kwargs)
+                    result = func(*args, **kwargs)
                     
                     # Check if we should retry based on the result
                     if retry_on_result and retry_on_result(result):

--- a/docs/failing_tests.md
+++ b/docs/failing_tests.md
@@ -1,0 +1,58 @@
+# Failing Tests Overview
+
+The following tests currently fail when running the test suite with `pytest`.
+Each entry includes the test module and the specific test cases that need to be
+addressed.
+
+## tests/core
+
+- **test_error_utilities.py** – fails to import `retry_exponential` during test collection.
+- **test_input_validation.py**
+  - `BasicValidatorsTest.test_validate_max_value`
+  - `BasicValidatorsTest.test_validate_min_value`
+  - `BasicValidatorsTest.test_validate_range`
+  - `ComplexValidatorsTest.test_validate_list_items`
+  - `UtilityFunctionsTest.test_create_schema_validator`
+  - `PrebuiltValidatorsTest.test_numeric_validators`
+  - `IntegrationTest.test_real_world_example`
+- **test_retry_mechanisms.py**
+  - `RetryUtilitiesTests.test_can_retry_with_exception_predicate`
+  - `RetryUtilitiesTests.test_can_retry_with_wait_strategy`
+
+## tests/common
+
+- **test_codehem2.py**
+  - `CodeHem2Tests.test_get_property_methods_by_xpath`
+  - `CodeHem2Tests.test_get_text_by_xpath`
+  - `CodeHem2Tests.test_get_text_by_xpath_properties`
+
+## tests/python
+
+- **test_element_extraction.py**
+  - `test_extract_property`
+  - `test_extract_imports`
+- **test_xpath_results.py**
+  - `test_property_getter`
+  - `test_property_setter`
+  - `test_property_setter_def`
+  - `test_property_setter_body`
+  - `test_duplicated_method`
+  - `test_getter_vs_setter`
+
+## Other integration tests
+
+- **test_full_integration.py**
+  - `FullIntegrationTest.test_python_complex_code`
+  - `FullIntegrationTest.test_typescript_complex_code`
+- **test_post_processor_integration.py**
+  - `PostProcessorIntegrationTest.test_post_processor_factory_registration`
+  - `PostProcessorIntegrationTest.test_post_processor_instantiation`
+- **test_refactored_extraction_service.py**
+  - `TestExtractionService.test_find_element`
+- **typescript/test_element_extraction.py**
+  - `test_extract_ts_interface`
+  - `test_extract_ts_imports`
+
+In total there are **28 failing tests** plus the import error in
+`test_error_utilities.py`. These tests will require updates to bring the suite
+back to a passing state.


### PR DESCRIPTION
## Summary
- implement simplified helper utilities for error logging and graceful
  degradation
- export helpers through error utilities package
- handle tuples in `InvalidTypeError`
- simplify retry decorators to return original exceptions

## Testing
- `pytest tests/core/test_error_utilities.py -q`
