### PR TITLE
Fix validator logic and post processor

### DIFF
--- a/codehem/languages/lang_typescript/typescript_post_processor.py
+++ b/codehem/languages/lang_typescript/typescript_post_processor.py
@@ -3,16 +3,20 @@ from typing import List, Dict, Optional
 from codehem.models.code_element import CodeElement, CodeRange
 from codehem.models.enums import CodeElementType
 from pydantic import ValidationError
-from codehem.languages.post_processor_base import BaseExtractionPostProcessor
+from codehem.core.post_processors.base import LanguagePostProcessor
 
 logger = logging.getLogger(__name__)
 
-class TypeScriptExtractionPostProcessor(BaseExtractionPostProcessor):
+class TypeScriptExtractionPostProcessor(LanguagePostProcessor):
     """
     TypeScript/JavaScript specific implementation of extraction post-processing.
     Transforms raw extraction dicts into structured CodeElement objects.
     V3: Adds helper for decorator processing, passes decorator lookup.
     """
+
+    def __init__(self) -> None:
+        """Initialize the TypeScript post processor."""
+        super().__init__("typescript")
 
     # --- process_imports (unchanged from previous thought process, assuming it's mostly correct) ---
     def process_imports(self, raw_imports: List[Dict]) -> List[CodeElement]:


### PR DESCRIPTION
## Summary
- register TypeScript post processor with the expected base class
- tweak validation helpers to treat `not_empty` fields as required and obey `__allow_unknown_fields`

## Testing
- `pytest tests/test_post_processor_integration.py::PostProcessorIntegrationTest::test_post_processor_factory_registration tests/test_post_processor_integration.py::PostProcessorIntegrationTest::test_post_processor_instantiation tests/core/test_input_validation.py::UtilityFunctionsTest::test_create_schema_validator tests/core/test_input_validation.py::IntegrationTest::test_real_world_example -q`
- `pytest -q` *(fails: 16 failed, 129 passed)*