### PR TITLE
Start Sprint 3

### DIFF
--- a/codehem-lang-template/cookiecutter.json
+++ b/codehem-lang-template/cookiecutter.json
@@ -1,0 +1,4 @@
+{
+  "language_slug": "lang_example",
+  "language_name": "Example"
+}

--- a/codehem-lang-template/{{cookiecutter.language_slug}}/formatter.py
+++ b/codehem-lang-template/{{cookiecutter.language_slug}}/formatter.py
@@ -1,0 +1,5 @@
+from codehem.core.formatting.formatter import BaseFormatter
+
+class {{cookiecutter.language_name}}Formatter(BaseFormatter):
+    """Formatter for {{cookiecutter.language_name}}."""
+    pass

--- a/codehem-lang-template/{{cookiecutter.language_slug}}/service.py
+++ b/codehem-lang-template/{{cookiecutter.language_slug}}/service.py
@@ -1,0 +1,6 @@
+from codehem.core.registry import language_service
+from codehem.core.language_service import LanguageService
+
+@language_service
+class {{cookiecutter.language_name}}LanguageService(LanguageService):
+    LANGUAGE_CODE = "{{cookiecutter.language_slug}}"

--- a/codehem-lang-template/{{cookiecutter.language_slug}}/tests/test_basic.py.template
+++ b/codehem-lang-template/{{cookiecutter.language_slug}}/tests/test_basic.py.template
@@ -1,0 +1,5 @@
+import unittest
+
+class Test{{cookiecutter.language_name}}(unittest.TestCase):
+    def test_placeholder(self):
+        self.assertTrue(True)

--- a/codehem/languages/lang_javascript/__init__.py
+++ b/codehem/languages/lang_javascript/__init__.py
@@ -1,0 +1,4 @@
+"""JavaScript language module for CodeHem."""
+from .service import JavaScriptLanguageService
+from .config import LANGUAGE_CONFIG
+from .detector import JavaScriptLanguageDetector

--- a/codehem/languages/lang_javascript/config.py
+++ b/codehem/languages/lang_javascript/config.py
@@ -1,0 +1,6 @@
+from codehem.languages.lang_typescript.config import (
+    LANGUAGE_CONFIG as TS_CONFIG,
+)
+
+LANGUAGE_CONFIG = dict(TS_CONFIG)
+LANGUAGE_CONFIG["language_code"] = "javascript"

--- a/codehem/languages/lang_javascript/detector.py
+++ b/codehem/languages/lang_javascript/detector.py
@@ -1,0 +1,23 @@
+import re
+from typing import List
+from codehem.core.detector import BaseLanguageDetector
+from codehem.core.registry import language_detector
+
+@language_detector
+class JavaScriptLanguageDetector(BaseLanguageDetector):
+    """Simple heuristic detector for JavaScript code."""
+
+    @property
+    def language_code(self) -> str:
+        return "javascript"
+
+    @property
+    def file_extensions(self) -> List[str]:
+        return [".js", ".jsx"]
+
+    def detect_confidence(self, code: str) -> float:
+        if not code.strip():
+            return 0.0
+        patterns = [r"function\b", r"=>", r"\bexport\b", r"\b(var|let|const)\b"]
+        matches = sum(bool(re.search(p, code)) for p in patterns)
+        return min(1.0, matches / len(patterns))

--- a/codehem/languages/lang_javascript/service.py
+++ b/codehem/languages/lang_javascript/service.py
@@ -1,0 +1,7 @@
+from codehem.core.registry import language_service
+from codehem.languages.lang_typescript.service import TypeScriptLanguageService
+
+@language_service
+class JavaScriptLanguageService(TypeScriptLanguageService):
+    """JavaScript service aliasing the TypeScript implementation."""
+    LANGUAGE_CODE = "javascript"

--- a/tests/common/test_javascript_alias.py
+++ b/tests/common/test_javascript_alias.py
@@ -1,0 +1,22 @@
+import unittest
+from codehem import CodeHem
+from codehem.languages import get_language_service_for_code, get_language_service
+from codehem.languages.lang_typescript.service import TypeScriptLanguageService
+
+
+class JavaScriptAliasTests(unittest.TestCase):
+    def test_service_alias(self):
+        js_service = get_language_service("javascript")
+        ts_service = get_language_service("typescript")
+        self.assertIsNotNone(js_service)
+        self.assertIsNotNone(ts_service)
+        self.assertIsInstance(js_service, TypeScriptLanguageService)
+
+    def test_javascript_detection(self):
+        code = "function greet() { console.log('hi'); }"
+        service = get_language_service_for_code(code)
+        self.assertIsNotNone(service)
+        self.assertIn(service.language_code, ("javascript", "typescript"))
+        hem = CodeHem("javascript")
+        self.assertEqual(hem.language_service.language_code, "javascript")
+


### PR DESCRIPTION
## Summary
- add plugin loader via entry points
- alias JavaScript to TypeScript language service
- provide a JavaScript language detector
- include minimal cookiecutter template
- test JavaScript alias functionality

## Testing
- `ruff check . --exit-zero | head`
- `black --check codehem/languages/lang_javascript tests/common/test_javascript_alias.py codehem/core/registry.py -q`
- `pytest -q`