### PR TITLE
Implement Sprint 4 foundations

### DIFF
--- a/codehem/core/formatting/__init__.py
+++ b/codehem/core/formatting/__init__.py
@@ -1,0 +1,3 @@
+from .formatter import BaseFormatter
+from .indent_formatter import IndentFormatter
+from .brace_formatter import BraceFormatter

--- a/codehem/core/formatting/brace_formatter.py
+++ b/codehem/core/formatting/brace_formatter.py
@@ -1,0 +1,8 @@
+from .formatter import BaseFormatter
+
+class BraceFormatter(BaseFormatter):
+    """Formatter for brace-based languages."""
+
+    def apply_indentation(self, code: str, base_indent: str) -> str:
+        dedented = self.dedent(code)
+        return super().apply_indentation(dedented, base_indent)

--- a/codehem/core/formatting/formatter.py
+++ b/codehem/core/formatting/formatter.py
@@ -60,6 +60,16 @@ class BaseFormatter:
         """
         return code
 
+    def _fix_spacing(self, code: str) -> str:
+        """Basic spacing normalization used by indent-based formatters."""
+        code = re.sub(r'([^\s=!<>])=([^\s=])', r'\1 = \2', code)
+        code = re.sub(r'([^\s!<>])==([^\s])', r'\1 == \2', code)
+        code = re.sub(r'([^\s])([+\-*/%])', r'\1 \2', code)
+        code = re.sub(r',([^\s])', r', \1', code)
+        code = re.sub(r'([^\s]):([^\s])', r'\1: \2', code)
+        code = re.sub(r'\n\s*\n\s*\n', r'\n\n', code)
+        return code
+
     def apply_indentation(self, code: str, base_indent: str) -> str:
         """
         Apply indentation to the code.

--- a/codehem/core/formatting/indent_formatter.py
+++ b/codehem/core/formatting/indent_formatter.py
@@ -1,0 +1,13 @@
+from .formatter import BaseFormatter
+
+class IndentFormatter(BaseFormatter):
+    """Formatter for indentation-based languages."""
+
+    def apply_indentation(self, code: str, base_indent: str) -> str:
+        dedented = self.dedent(code)
+        return super().apply_indentation(dedented, base_indent)
+
+    def format_code(self, code: str) -> str:
+        code = code.strip()
+        code = self._fix_spacing(code)
+        return code

--- a/codehem/core/manipulators/abstract_block_manipulator.py
+++ b/codehem/core/manipulators/abstract_block_manipulator.py
@@ -1,0 +1,19 @@
+from typing import Optional
+from .manipulator_base import ManipulatorBase
+
+class AbstractBlockManipulator(ManipulatorBase):
+    """Manipulator with generic block insertion logic."""
+
+    BLOCK_START_TOKEN = '{'
+
+    def add_element(self, original_code: str, new_element: str, parent_name: Optional[str] = None) -> str:
+        lines = original_code.splitlines()
+        insertion_line = len(lines)
+        indent_level = 0
+        if parent_name:
+            start, end = self.find_element(original_code, parent_name)
+            if end > 0:
+                insertion_line = end
+                indent_level = self.get_element_indent_level(original_code, start, parent_name) + 1
+        formatted = self.format_element(new_element, indent_level)
+        return self.replace_lines(original_code, insertion_line, insertion_line, formatted)

--- a/codehem/languages/lang_python/config.py
+++ b/codehem/languages/lang_python/config.py
@@ -1,43 +1,18 @@
 """
 Language-specific configuration for Python in CodeHem.
 """
+import json
+from pathlib import Path
 from codehem.models.enums import CodeElementType
 from .python_post_processor import PythonExtractionPostProcessor
 
-# Define a specific Tree-sitter query for Python imports
-_PY_IMPORT_QUERY = """
-(import_statement) @import_simple
-(import_from_statement) @import_from
-"""
-# Simplified Python property/method queries (v5) - Minimal valid structure
-_PY_METHOD_QUERY = "(function_definition name: (identifier) @method_name) @method_def"
-_PY_FUNC_QUERY = "(function_definition name: (identifier) @function_name) @function_def"
-# Capture decorated definition; extractor must check decorator content
-_PY_GETTER_QUERY = "(decorated_definition) @getter_def"
-_PY_SETTER_QUERY = "(decorated_definition) @setter_def"
-# Corrected Static Property Query (v7) - Fixed valid syntax
-_PY_STATIC_PROP_QUERY = """
-(class_definition 
-  body: (block) @class_block)
-"""
-_PY_DECORATOR_QUERY = "(decorator) @decorator_node"
-_PY_CLASS_QUERY = "(class_definition name: (identifier) @class_name) @class_def"
-
-# Provide only necessary keys for placeholders, primarily 'tree_sitter_query' to override base templates
-PYTHON_PLACEHOLDERS = {
-    CodeElementType.CLASS:           {'tree_sitter_query': _PY_CLASS_QUERY},
-    CodeElementType.METHOD:          {'tree_sitter_query': _PY_METHOD_QUERY},
-    CodeElementType.FUNCTION:        {'tree_sitter_query': _PY_FUNC_QUERY},
-    CodeElementType.IMPORT:          {'tree_sitter_query': _PY_IMPORT_QUERY, 'custom_extract': True},
-    CodeElementType.PROPERTY_GETTER: {'tree_sitter_query': _PY_GETTER_QUERY},
-    CodeElementType.PROPERTY_SETTER: {'tree_sitter_query': _PY_SETTER_QUERY},
-    CodeElementType.STATIC_PROPERTY: {'tree_sitter_query': _PY_STATIC_PROP_QUERY},
-    CodeElementType.DECORATOR:       {'tree_sitter_query': _PY_DECORATOR_QUERY}
-    # Regex patterns are removed here as TS query should be primary
-}
+_patterns_path = Path(__file__).with_name("node_patterns.json")
+with _patterns_path.open() as f:
+    _raw = json.load(f)
+PYTHON_PLACEHOLDERS = {CodeElementType[k]: v for k, v in _raw.items()}
 
 LANGUAGE_CONFIG = {
     'language_code': 'python',
     'post_processor_class': PythonExtractionPostProcessor,
-    'template_placeholders': PYTHON_PLACEHOLDERS
+    'template_placeholders': PYTHON_PLACEHOLDERS,
 }

--- a/codehem/languages/lang_python/formatting/__init__.py
+++ b/codehem/languages/lang_python/formatting/__init__.py
@@ -1,0 +1,1 @@
+from .python_formatter import PythonFormatter

--- a/codehem/languages/lang_python/formatting/python_formatter.py
+++ b/codehem/languages/lang_python/formatting/python_formatter.py
@@ -4,11 +4,11 @@ Python-specific formatter implementation.
 import re
 from typing import Callable, Optional
 
-from codehem.core.formatting.formatter import BaseFormatter
+from codehem.core.formatting.indent_formatter import IndentFormatter
 from codehem.models.enums import CodeElementType
 
 
-class PythonFormatter(BaseFormatter):
+class PythonFormatter(IndentFormatter):
     """
     Python-specific implementation of the code formatter.
     """
@@ -236,21 +236,3 @@ class PythonFormatter(BaseFormatter):
         """
         lines = self.dedent(code).strip().splitlines()
         return '\n'.join((line.strip() for line in lines if line.strip()))
-
-    def _fix_spacing(self, code: str) -> str:
-        """
-        Fix spacing issues in Python code.
-        
-        Args:
-            code: Python code to fix
-            
-        Returns:
-            Code with fixed spacing
-        """
-        code = re.sub('([^\\s=!<>])=([^\\s=])', '\\1 = \\2', code)
-        code = re.sub('([^\\s!<>])==[^\\s]', '\\1 == \\2', code)
-        code = re.sub('([^\\s])([+\\-*/%])', '\\1 \\2', code)
-        code = re.sub(',([^\\s])', ', \\1', code)
-        code = re.sub('([^\\s]):([^\\s])', '\\1: \\2', code)
-        code = re.sub('\\n\\s*\\n\\s*\\n', '\\n\\n', code)
-        return code

--- a/codehem/languages/lang_python/manipulator/base.py
+++ b/codehem/languages/lang_python/manipulator/base.py
@@ -4,18 +4,19 @@ Base manipulator for Python-specific manipulators.
 import logging
 from typing import Optional
 
-from codehem.core.manipulators.manipulator_base import ManipulatorBase
+from codehem.core.manipulators.abstract_block_manipulator import AbstractBlockManipulator
 from codehem.core.formatting.formatter import BaseFormatter
 from codehem.core.registry import registry
 from codehem.models.enums import CodeElementType
 from codehem.languages.lang_python.formatting.python_formatter import PythonFormatter
 logger = logging.getLogger(__name__)
 
-class PythonManipulatorBase(ManipulatorBase):
+class PythonManipulatorBase(AbstractBlockManipulator):
     """Base class for Python-specific manipulators."""
     LANGUAGE_CODE = 'python'
     COMMENT_MARKERS = ['#']
     DECORATOR_MARKERS = ['@']
+    BLOCK_START_TOKEN = ':'
 
     def __init__(self, element_type: CodeElementType = None, formatter: BaseFormatter = None, 
                  extraction_service = None):

--- a/codehem/languages/lang_python/node_patterns.json
+++ b/codehem/languages/lang_python/node_patterns.json
@@ -1,0 +1,10 @@
+{
+  "CLASS": {"tree_sitter_query": "(class_definition name: (identifier) @class_name) @class_def"},
+  "METHOD": {"tree_sitter_query": "(function_definition name: (identifier) @method_name) @method_def"},
+  "FUNCTION": {"tree_sitter_query": "(function_definition name: (identifier) @function_name) @function_def"},
+  "IMPORT": {"tree_sitter_query": "(import_statement) @import_simple\n(import_from_statement) @import_from", "custom_extract": true},
+  "PROPERTY_GETTER": {"tree_sitter_query": "(decorated_definition) @getter_def"},
+  "PROPERTY_SETTER": {"tree_sitter_query": "(decorated_definition) @setter_def"},
+  "STATIC_PROPERTY": {"tree_sitter_query": "(class_definition\n  body: (block) @class_block)"},
+  "DECORATOR": {"tree_sitter_query": "(decorator) @decorator_node"}
+}

--- a/codehem/languages/lang_typescript/formatting/__init__.py
+++ b/codehem/languages/lang_typescript/formatting/__init__.py
@@ -1,6 +1,1 @@
-""" Formatting utilities for TypeScript/JavaScript. """
-# Leave this file empty or with just the docstring.
-# The formatter class can be imported directly where needed or loaded by the LanguageService.
-# For simplicity in discovery, we keep the import in the main lang_typescript/__init__.py
-# from .typescript_formatter import TypeScriptFormatter
-# __all__ = ['TypeScriptFormatter']
+from .typescript_formatter import TypeScriptFormatter

--- a/codehem/languages/lang_typescript/formatting/typescript_formatter.py
+++ b/codehem/languages/lang_typescript/formatting/typescript_formatter.py
@@ -5,10 +5,10 @@ Provides basic formatting rules.
 import re
 import textwrap
 from typing import Callable, Optional
-from codehem.core.formatting.formatter import BaseFormatter
+from codehem.core.formatting.brace_formatter import BraceFormatter
 from codehem.models.enums import CodeElementType
 
-class TypeScriptFormatter(BaseFormatter):
+class TypeScriptFormatter(BraceFormatter):
     """
     TypeScript/JavaScript specific implementation of the code formatter.
     Applies basic indentation and spacing rules.

--- a/tests/core/test_new_formatters.py
+++ b/tests/core/test_new_formatters.py
@@ -1,0 +1,15 @@
+from codehem.core.formatting import IndentFormatter, BraceFormatter
+
+
+def test_indent_formatter_basic():
+    fmt = IndentFormatter()
+    src = "line1\n    line2"
+    result = fmt.apply_indentation(src, "    ")
+    assert result.splitlines()[0] == "    line1"
+
+
+def test_brace_formatter_dedent():
+    fmt = BraceFormatter()
+    src = "{\n    inner;\n}"
+    result = fmt.apply_indentation(src, "")
+    assert result.splitlines()[0] == "{"


### PR DESCRIPTION
## Summary
- introduce `IndentFormatter` and `BraceFormatter`
- share `_fix_spacing` in `BaseFormatter`
- add `AbstractBlockManipulator` and use in Python
- load Python node patterns from JSON
- basic tests for new formatters

## Testing
- `pytest -q`