### PR TITLE
Implement patch API - Sprint 5

### DIFF
--- a/codehem/core/error_handling.py
+++ b/codehem/core/error_handling.py
@@ -282,6 +282,17 @@ class ReplaceElementError(ManipulationError):
         self.element_name = element_name
         self.reason = reason
 
+class WriteConflictError(ManipulationError):
+    """Raised when apply_patch detects hash mismatch for the target fragment."""
+
+    def __init__(self, expected_hash: str, actual_hash: str, **kwargs):
+        message = (
+            f"Write conflict: expected hash {expected_hash} but found {actual_hash}"
+        )
+        super().__init__(message, expected_hash=expected_hash, actual_hash=actual_hash, **kwargs)
+        self.expected_hash = expected_hash
+        self.actual_hash = actual_hash
+
 # ===== Post-Processing Errors =====
 
 class PostProcessorError(CodeHemError):

--- a/codehem/core/utils/hashing.py
+++ b/codehem/core/utils/hashing.py
@@ -4,3 +4,8 @@ import hashlib
 def sha1_code(code: str) -> str:
     """Return the SHA1 hash of the given code string."""
     return hashlib.sha1(code.encode("utf8")).hexdigest()
+
+
+def sha256_code(code: str) -> str:
+    """Return the SHA256 hash of the given code string."""
+    return hashlib.sha256(code.encode("utf8")).hexdigest()

--- a/tests/test_patch_api.py
+++ b/tests/test_patch_api.py
@@ -1,0 +1,40 @@
+import pytest
+from codehem import CodeHem
+from codehem.core.error_handling import WriteConflictError
+
+
+SAMPLE_CODE = """\
+def foo():
+    return 1
+"""
+
+
+def test_apply_patch_replace():
+    hem = CodeHem('python')
+    xpath = 'foo[function]'
+    original_hash = hem.get_element_hash(SAMPLE_CODE, xpath)
+    assert original_hash
+    new_fragment = "def foo():\n    return 2"
+    result = hem.apply_patch(SAMPLE_CODE, xpath, new_fragment, original_hash=original_hash)
+    assert result['status'] == 'ok'
+    assert result['lines_added'] == 1
+    assert result['lines_removed'] == 1
+    assert 'return 2' in result['code']
+
+
+def test_apply_patch_append():
+    hem = CodeHem('python')
+    xpath = 'foo[function]'
+    original_hash = hem.get_element_hash(SAMPLE_CODE, xpath)
+    result = hem.apply_patch(SAMPLE_CODE, xpath, 'print("hi")', mode='append', original_hash=original_hash)
+    assert result['lines_added'] == 1
+    assert result['lines_removed'] == 0
+    assert 'print("hi")' in result['code']
+
+
+def test_apply_patch_conflict():
+    hem = CodeHem('python')
+    xpath = 'foo[function]'
+    wrong_hash = '0' * 64
+    with pytest.raises(WriteConflictError):
+        hem.apply_patch(SAMPLE_CODE, xpath, 'print()', original_hash=wrong_hash)


### PR DESCRIPTION
## Summary
- start Sprint 5
- add `sha256_code` helper and `WriteConflictError`
- extend CodeHem with `get_element_hash` and `apply_patch`
- support optional `return_hash` in `get_text_by_xpath`
- cover new functionality with tests

## Testing
- `pytest -q`
