### PR TITLE
Complete Sprint 7 docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 | 4      | 🚧 queued      | DRY formatter/manipulator refactor                                  |
 | 5      | 🚧 planned     | Patch API (`apply_patch`, `get_element_hash`)                       |
 | 6      | 🟢 in-progress | Builder helpers, short XPath, JSON results                          |
-| 7      | 🚧 planned     | Workspace index, locks, thread‑safety                               |
+| 7      | ✅ done         | Workspace index, locks, thread‑safety                               |
 | 8      | 🚧 planned     | Docs, CLI polish, first public release 1.0                          |
 
 Anything beyond Sprint 3 is subject to change; check issues before diving into those areas.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ Output (truncated):
 
 The **full file never left runtime memory** – ideal for token‑budgeted agents.
 
+### Workspace example
+```python
+ws = CodeHem.open_workspace("/path/to/repo")
+file, xp = ws.find(name="calculate", kind="function")
+ws.apply_patch(file, xp, "def calculate(x):\n    return x * 2\n")
+```
+
 ### Builder helpers
 
 Generate new functions or classes from structured data:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,6 +114,8 @@ Minimalizacja promptów LLM – agent przekazuje czysty JSON, CodeHem generuje s
 
 ## Sprint 7 — Workspace & thread-safe writes
 
+### Status: ✅ zakończono
+
 ### Co robimy
 
 * `workspace = CodeHem.open_workspace(repo_root)`


### PR DESCRIPTION
## Summary
- mark Sprint 7 as complete in ROADMAP and AGENTS
- document workspace usage in README

## Testing
- `ruff check tests/test_workspace.py`
- `black tests/test_workspace.py`
- `pytest -q`
