### PR TITLE
Finish Sprint 4 pieces

### DIFF
--- a/codehem/languages/lang_typescript/__init__.py
+++ b/codehem/languages/lang_typescript/__init__.py
@@ -7,23 +7,27 @@ Other components like type descriptors, extractors, and manipulators should be i
 directly by the modules that use them or discovered dynamically by the registry
 and language service.
 """
-from . import config
-from . import detector
-from . import service
-from . import components  # Import TypeScript components
-from .formatting import typescript_formatter
+
+from . import config  # noqa: F401
+from . import detector  # noqa: F401
+from . import service  # noqa: F401
+from . import components  # noqa: F401 - Register components
+from .formatting import typescript_formatter  # noqa: F401
 
 # Import newly added type descriptors to ensure registration
-from . import type_class
-from . import type_function
-from . import type_import
-from . import type_interface
-from . import type_method
-from . import type_property
-from . import type_static_property
-from . import type_decorator
-from . import type_alias
-from . import type_enum
-from . import type_namespace
-from . import type_property_getter
-from . import type_property_setter
+from . import type_class  # noqa: F401
+from . import type_function  # noqa: F401
+from . import type_import  # noqa: F401
+from . import type_interface  # noqa: F401
+from . import type_method  # noqa: F401
+from . import type_property  # noqa: F401
+from . import type_static_property  # noqa: F401
+from . import type_decorator  # noqa: F401
+from . import type_alias  # noqa: F401
+from . import type_enum  # noqa: F401
+from . import type_namespace  # noqa: F401
+from . import type_property_getter  # noqa: F401
+from . import type_property_setter  # noqa: F401
+
+# Register manipulators
+from .manipulator import base  # noqa: F401

--- a/codehem/languages/lang_typescript/config.py
+++ b/codehem/languages/lang_typescript/config.py
@@ -5,6 +5,8 @@
 Language-specific configuration for TypeScript/JavaScript in CodeHem.
 (Combined Corrected Queries, Capture Names, and Placeholders)
 """
+import json
+from pathlib import Path
 from codehem.models.enums import CodeElementType
 from .typescript_post_processor import TypeScriptExtractionPostProcessor
 from .formatting.typescript_formatter import TypeScriptFormatter
@@ -90,14 +92,14 @@ _TS_CLASS_QUERY = """
 """
 
 # Methods / Getters / Setters - REVISED (Removed invalid predicates, capture modifiers as children)
-_TS_METHOD_QUERY = '''
+_TS_METHOD_QUERY = """
 (method_definition
   name: (property_identifier) @method_name
   parameters: (formal_parameters) @params
   return_type: (type_annotation)? @return_type
   body: (statement_block)? @body
 ) @method_def
-'''
+"""
 
 # Properties (Class Fields / Interface Signatures) - REVISED
 _TS_PROPERTY_QUERY = """
@@ -173,107 +175,30 @@ _TS_NAMESPACE_QUERY = """
 """
 
 # --- Regex Placeholder Definitions (simplified, primarily for reference) ---
-_IDENTIFIER = '[a-zA-Z_$][a-zA-Z0-9_$]*'
-_PARAMS = '[^)]*'
-_TYPE_ANNOTATION = '(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s\'"{}()=>]+)?'
-_RETURN_TYPE = '(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s\'"{}()=>]+)'
-_OPTIONAL_ASYNC = '(?:async\\s+)?'
-_OPTIONAL_ACCESS = '(?:(?:public|private|protected|static|readonly)\\s+)*'
-_BODY_START = '{'
-_DECORATOR_REGEX = '@' + _IDENTIFIER + '(?:\\([^)]*\\))?'
-_INHERITANCE = '(?:\\s+(?:extends|implements)\\s+[\\w.,\\s<>]+)?'
-_FIRST_PARAM = '(?:this|' + _IDENTIFIER + ')'
-_VALUE_CAPTURE = '.+?'
-_OPTIONAL_COMMENT_ENDLINE = '(?:$|\\s*//|\\s*/\\*)'
+_IDENTIFIER = "[a-zA-Z_$][a-zA-Z0-9_$]*"
+_PARAMS = "[^)]*"
+_TYPE_ANNOTATION = "(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s'\"{}()=>]+)?"
+_RETURN_TYPE = "(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s'\"{}()=>]+)"
+_OPTIONAL_ASYNC = "(?:async\\s+)?"
+_OPTIONAL_ACCESS = "(?:(?:public|private|protected|static|readonly)\\s+)*"
+_BODY_START = "{"
+_DECORATOR_REGEX = "@" + _IDENTIFIER + "(?:\\([^)]*\\))?"
+_INHERITANCE = "(?:\\s+(?:extends|implements)\\s+[\\w.,\\s<>]+)?"
+_FIRST_PARAM = "(?:this|" + _IDENTIFIER + ")"
+_VALUE_CAPTURE = ".+?"
+_OPTIONAL_COMMENT_ENDLINE = "(?:$|\\s*//|\\s*/\\*)"
 
 # --- Mapping Element Types to Queries and Placeholders ---
-TS_PLACEHOLDERS = {
-    CodeElementType.CLASS: {
-        'tree_sitter_query': _TS_CLASS_QUERY,
-        'CLASS_NODE': 'class_declaration', 'NAME_NODE': 'type_identifier', 'BODY_NODE': 'class_body',
-        'CLASS_PATTERN': '(?:export\\s+)?(?:abstract\\s+)?class', 'IDENTIFIER_PATTERN': _IDENTIFIER,
-        'INHERITANCE_PATTERN': _INHERITANCE, 'BODY_START': _BODY_START
-    },
-    CodeElementType.INTERFACE: {
-        'tree_sitter_query': _TS_INTERFACE_QUERY, # Uses interface_body
-        'INTERFACE_NODE': 'interface_declaration', 'NAME_NODE': 'type_identifier', 'BODY_NODE': 'interface_body',
-        'INTERFACE_PATTERN': '(?:export\\s+)?interface', 'IDENTIFIER_PATTERN': _IDENTIFIER,
-        'EXTENDS_PATTERN': '(?:\\s+extends\\s+[\\w.,\\s<>]+)?', 'BODY_START': _BODY_START
-    },
-    CodeElementType.METHOD: {
-        'tree_sitter_query': _TS_METHOD_QUERY, # Uses REVISED query
-        'NAME_NODE': 'property_identifier', 'FIRST_PARAM_ID': 'this',
-        'METHOD_PATTERN': _OPTIONAL_ACCESS + _OPTIONAL_ASYNC + _IDENTIFIER, 'IDENTIFIER_PATTERN': _IDENTIFIER,
-        'RETURN_TYPE_PATTERN': _RETURN_TYPE + '?', 'BODY_START': _BODY_START
-    },
-    CodeElementType.FUNCTION: {
-        'tree_sitter_query': _TS_FUNCTION_QUERY,
-        'NAME_NODE': 'identifier', 'PARAMS_NODE': 'formal_parameters', 'RETURN_TYPE_NODE': 'type_annotation', 'BODY_NODE': 'statement_block',
-        'FUNCTION_PATTERN': '(?:export\\s+)?' + _OPTIONAL_ASYNC + 'function', 'IDENTIFIER_PATTERN': _IDENTIFIER,
-        'PARAMS_PATTERN': _PARAMS, 'RETURN_TYPE_PATTERN': _RETURN_TYPE + '?', 'BODY_START': _BODY_START,
-        'ARROW_FUNCTION_PATTERN': '(?:export\\s+)?(?:const|let)\\s+' + _IDENTIFIER + '\\s*[:]?.*=\\s*' + _OPTIONAL_ASYNC + '\\(?' + _PARAMS + '\\)?' + _RETURN_TYPE + '?\\s*=>'
-    },
-    CodeElementType.IMPORT: {
-        'tree_sitter_query': _TS_IMPORT_QUERY, # Uses simple query, logic issue likely elsewhere
-        'custom_extract': True,
-        'IMPORT_NODE': 'import_statement',
-        'IMPORT_PATTERN': '(?:^|\\n)\\s*(?:import(?:\\s+(?:[\\w*{},\\s]+)\\s+from)?\\s+[\'"].*?[\'"];?|export\\s+(?:\\*|{[^}]+})\\s+from\\s+[\'"].*?[\'"];?)'
-    },
-    CodeElementType.PROPERTY: {
-        'tree_sitter_query': _TS_PROPERTY_QUERY, # Uses REVISED query
-        'PROPERTY_NODE': 'public_field_definition', 'NAME_NODE': 'property_identifier', 'TYPE_NODE': 'type_annotation', 'VALUE_NODE': '_',
-        'PROPERTY_PATTERN': '(?:^|\\n)\\s*' + _OPTIONAL_ACCESS + '(?:readonly\\s+)?' + _IDENTIFIER + _TYPE_ANNOTATION + '?\\s*(?:=\\s*[^;\\n]+?)?\\s*;?',
-        'IDENTIFIER_PATTERN': _IDENTIFIER
-    },
-    CodeElementType.STATIC_PROPERTY: {
-        'tree_sitter_query': _TS_PROPERTY_QUERY, # Uses REVISED query (same as PROPERTY)
-        'STATIC_PROP_NODE': 'public_field_definition', 'NAME_NODE': 'property_identifier',
-        'IDENTIFIER_PATTERN': _IDENTIFIER, 'OPTIONAL_NEWLINE_INDENT': '(?:^|\\n)\\s+',
-        'OPTIONAL_TYPE_HINT': _TYPE_ANNOTATION + '?', 'VALUE_CAPTURE': _VALUE_CAPTURE,
-        'OPTIONAL_COMMENT_ENDLINE': _OPTIONAL_COMMENT_ENDLINE
-    },
-    CodeElementType.PROPERTY_GETTER: {
-        'tree_sitter_query': _TS_METHOD_QUERY, # Uses REVISED METHOD query
-        'NAME_NODE': 'property_identifier', 'GETTER_DECORATOR_ID': 'get',
-        'GETTER_DECORATOR_PATTERN': _OPTIONAL_ACCESS + 'get', 'METHOD_PATTERN': 'get\\s+' + _IDENTIFIER,
-        'IDENTIFIER_PATTERN': _IDENTIFIER, 'FIRST_PARAM_PATTERN': '', 'RETURN_TYPE_PATTERN': _RETURN_TYPE + '?',
-        'BODY_CAPTURE_LOOKAHEAD': _BODY_START + '[\\s\\S]*'
-    },
-    CodeElementType.PROPERTY_SETTER: {
-        'tree_sitter_query': _TS_METHOD_QUERY, # Uses REVISED METHOD query
-        'NAME_NODE': 'property_identifier', 'SETTER_DECORATOR_ATTR': 'set',
-        'PROPERTY_NAME_PATTERN': _IDENTIFIER, 'SETTER_ATTR_PATTERN': 'set',
-        'METHOD_PATTERN': 'set\\s+' + _IDENTIFIER, 'IDENTIFIER_PATTERN': _IDENTIFIER,
-        'FIRST_PARAM_PATTERN': _IDENTIFIER, 'RETURN_TYPE_PATTERN': _RETURN_TYPE + '?',
-        'BODY_CAPTURE_LOOKAHEAD': _BODY_START + '[\\s\\S]*'
-    },
-    CodeElementType.DECORATOR: {
-        'tree_sitter_query': _TS_DECORATOR_QUERY, # Uses REVISED query
-        'DECORATOR_NODE': 'decorator', 'DECORATOR_PREFIX': '@',
-        'QUALIFIED_NAME_PATTERN': _IDENTIFIER + '(?:\\.' + _IDENTIFIER + ')*',
-        'ARGS_PATTERN': '(?:\\([^)]*\\))?'
-    },
-    CodeElementType.TYPE_ALIAS: {
-        'tree_sitter_query': _TS_TYPE_ALIAS_QUERY,
-        'TYPE_NODE': 'type_alias_declaration', 'NAME_NODE': 'type_identifier', 'VALUE_NODE': '_',
-        'TYPE_PATTERN': '(?:export\\s+)?type', 'IDENTIFIER_PATTERN': _IDENTIFIER
-    },
-    CodeElementType.ENUM: {
-        'tree_sitter_query': _TS_ENUM_QUERY,
-        'ENUM_NODE': 'enum_declaration', 'NAME_NODE': 'identifier', 'BODY_NODE': 'enum_body',
-        'ENUM_PATTERN': '(?:export\\s+)?enum'
-    },
-    CodeElementType.NAMESPACE: {
-        'tree_sitter_query': _TS_NAMESPACE_QUERY,
-        'NAMESPACE_NODE': 'module', 'NAME_NODE': 'identifier', 'BODY_NODE': 'module_body',
-        'NAMESPACE_PATTERN': '(?:export\\s+)?(?:namespace|module)'
-    }
-}
+_patterns_path = Path(__file__).with_name("node_patterns.json")
+with _patterns_path.open() as f:
+    _raw_patterns = json.load(f)
+TS_PLACEHOLDERS = {CodeElementType(k): v for k, v in _raw_patterns.items()}
+
 
 # --- Main Language Configuration Dictionary ---
 LANGUAGE_CONFIG = {
-    'language_code': 'typescript',
-    'formatter_class': TypeScriptFormatter,
-    'post_processor_class': TypeScriptExtractionPostProcessor,
-    'template_placeholders': TS_PLACEHOLDERS
+    "language_code": "typescript",
+    "formatter_class": TypeScriptFormatter,
+    "post_processor_class": TypeScriptExtractionPostProcessor,
+    "template_placeholders": TS_PLACEHOLDERS,
 }

--- a/codehem/languages/lang_typescript/manipulator/base.py
+++ b/codehem/languages/lang_typescript/manipulator/base.py
@@ -1,0 +1,39 @@
+"""Base manipulator for TypeScript/JavaScript."""
+
+from codehem.core.manipulators.abstract_block_manipulator import (
+    AbstractBlockManipulator,
+)
+from codehem.core.formatting.brace_formatter import BraceFormatter
+from codehem.core.registry import registry
+from codehem.models.enums import CodeElementType
+
+
+class TypeScriptManipulatorBase(AbstractBlockManipulator):
+    """Base class for TypeScript-specific manipulators."""
+
+    LANGUAGE_CODE = "typescript"
+    COMMENT_MARKERS = ["//"]
+    DECORATOR_MARKERS = ["@"]
+    BLOCK_START_TOKEN = "{"
+
+    def __init__(
+        self,
+        element_type: CodeElementType | None = None,
+        formatter: BraceFormatter | None = None,
+        extraction_service=None,
+    ) -> None:
+        if formatter is None:
+            try:
+                lang_service = registry.get_language_service("typescript")
+                if lang_service and hasattr(lang_service, "formatter"):
+                    formatter = lang_service.formatter
+                else:
+                    formatter = BraceFormatter()
+            except Exception:
+                formatter = BraceFormatter()
+        super().__init__(
+            language_code="typescript",
+            element_type=element_type,
+            formatter=formatter,
+            extraction_service=extraction_service,
+        )

--- a/codehem/languages/lang_typescript/node_patterns.json
+++ b/codehem/languages/lang_typescript/node_patterns.json
@@ -1,0 +1,121 @@
+{
+  "class": {
+    "tree_sitter_query": "\n(class_declaration\n  name: (type_identifier) @class_name\n  body: (class_body) @class_body\n) @class_def\n\n(export_statement\n  declaration: (class_declaration\n    name: (type_identifier) @class_name\n    body: (class_body) @class_body\n  ) @class_def_exported\n)\n",
+    "CLASS_NODE": "class_declaration",
+    "NAME_NODE": "type_identifier",
+    "BODY_NODE": "class_body",
+    "CLASS_PATTERN": "(?:export\\s+)?(?:abstract\\s+)?class",
+    "IDENTIFIER_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "INHERITANCE_PATTERN": "(?:\\s+(?:extends|implements)\\s+[\\w.,\\s<>]+)?",
+    "BODY_START": "{"
+  },
+  "interface": {
+    "tree_sitter_query": "\n(interface_declaration\n  name: (type_identifier) @interface_name\n  body: (interface_body) @interface_body\n) @interface_def\n\n(export_statement\n  declaration: (interface_declaration\n    name: (type_identifier) @interface_name\n    body: (interface_body) @interface_body\n  ) @interface_def_exported\n)\n",
+    "INTERFACE_NODE": "interface_declaration",
+    "NAME_NODE": "type_identifier",
+    "BODY_NODE": "interface_body",
+    "INTERFACE_PATTERN": "(?:export\\s+)?interface",
+    "IDENTIFIER_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "EXTENDS_PATTERN": "(?:\\s+extends\\s+[\\w.,\\s<>]+)?",
+    "BODY_START": "{"
+  },
+  "method": {
+    "tree_sitter_query": "\n(method_definition\n  name: (property_identifier) @method_name\n  parameters: (formal_parameters) @params\n  return_type: (type_annotation)? @return_type\n  body: (statement_block)? @body\n) @method_def\n",
+    "NAME_NODE": "property_identifier",
+    "FIRST_PARAM_ID": "this",
+    "METHOD_PATTERN": "(?:(?:public|private|protected|static|readonly)\\s+)*(?:async\\s+)?[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "IDENTIFIER_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "RETURN_TYPE_PATTERN": "(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s'\"{}()=>]+)?",
+    "BODY_START": "{"
+  },
+  "function": {
+    "tree_sitter_query": "\n(function_declaration\n  name: (identifier) @function_name\n  parameters: (formal_parameters) @params\n  return_type: (type_annotation)? @return_type\n  body: (statement_block) @body\n) @function_def\n\n(export_statement\n  declaration: (function_declaration\n    name: (identifier) @function_name\n    parameters: (formal_parameters) @params\n    return_type: (type_annotation)? @return_type\n    body: (statement_block) @body\n  ) @function_def_exported\n)\n\n(lexical_declaration\n  (variable_declarator\n    name: (identifier) @function_name\n    value: (arrow_function\n      parameters: (_) @params\n      return_type: (type_annotation)? @return_type\n      body: (_) @arrow_func_body\n    )\n  )\n) @arrow_function_def\n\n(export_statement\n  declaration: (lexical_declaration\n    (variable_declarator\n      name: (identifier) @function_name\n      value: (arrow_function\n        parameters: (_) @params\n        return_type: (type_annotation)? @return_type\n        body: (_) @arrow_func_body\n      )\n    )\n  ) @arrow_function_def_exported\n)\n",
+    "NAME_NODE": "identifier",
+    "PARAMS_NODE": "formal_parameters",
+    "RETURN_TYPE_NODE": "type_annotation",
+    "BODY_NODE": "statement_block",
+    "FUNCTION_PATTERN": "(?:export\\s+)?(?:async\\s+)?function",
+    "IDENTIFIER_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "PARAMS_PATTERN": "[^)]*",
+    "RETURN_TYPE_PATTERN": "(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s'\"{}()=>]+)?",
+    "BODY_START": "{",
+    "ARROW_FUNCTION_PATTERN": "(?:export\\s+)?(?:const|let)\\s+[a-zA-Z_$][a-zA-Z0-9_$]*\\s*[:]?.*=\\s*(?:async\\s+)?\\(?[^)]*\\)?(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s'\"{}()=>]+)?\\s*=>"
+  },
+  "import": {
+    "tree_sitter_query": "\n(import_statement) @import_statement\n",
+    "custom_extract": true,
+    "IMPORT_NODE": "import_statement",
+    "IMPORT_PATTERN": "(?:^|\\n)\\s*(?:import(?:\\s+(?:[\\w*{},\\s]+)\\s+from)?\\s+['\"].*?['\"];?|export\\s+(?:\\*|{[^}]+})\\s+from\\s+['\"].*?['\"];?)"
+  },
+  "property": {
+    "tree_sitter_query": "\n(public_field_definition\n  name: (property_identifier) @property_name\n  type: (type_annotation)? @type\n  value: (_)? @value\n) @property_def\n",
+    "PROPERTY_NODE": "public_field_definition",
+    "NAME_NODE": "property_identifier",
+    "TYPE_NODE": "type_annotation",
+    "VALUE_NODE": "_",
+    "PROPERTY_PATTERN": "(?:^|\\n)\\s*(?:(?:public|private|protected|static|readonly)\\s+)*(?:readonly\\s+)?[a-zA-Z_$][a-zA-Z0-9_$]*(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s'\"{}()=>]+)??\\s*(?:=\\s*[^;\\n]+?)?\\s*;?",
+    "IDENTIFIER_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*"
+  },
+  "static_property": {
+    "tree_sitter_query": "\n(public_field_definition\n  name: (property_identifier) @property_name\n  type: (type_annotation)? @type\n  value: (_)? @value\n) @property_def\n",
+    "STATIC_PROP_NODE": "public_field_definition",
+    "NAME_NODE": "property_identifier",
+    "IDENTIFIER_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "OPTIONAL_NEWLINE_INDENT": "(?:^|\\n)\\s+",
+    "OPTIONAL_TYPE_HINT": "(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s'\"{}()=>]+)??",
+    "VALUE_CAPTURE": ".+?",
+    "OPTIONAL_COMMENT_ENDLINE": "(?:$|\\s*//|\\s*/\\*)"
+  },
+  "property_getter": {
+    "tree_sitter_query": "\n(method_definition\n  name: (property_identifier) @method_name\n  parameters: (formal_parameters) @params\n  return_type: (type_annotation)? @return_type\n  body: (statement_block)? @body\n) @method_def\n",
+    "NAME_NODE": "property_identifier",
+    "GETTER_DECORATOR_ID": "get",
+    "GETTER_DECORATOR_PATTERN": "(?:(?:public|private|protected|static|readonly)\\s+)*get",
+    "METHOD_PATTERN": "get\\s+[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "IDENTIFIER_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "FIRST_PARAM_PATTERN": "",
+    "RETURN_TYPE_PATTERN": "(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s'\"{}()=>]+)?",
+    "BODY_CAPTURE_LOOKAHEAD": "{[\\s\\S]*"
+  },
+  "property_setter": {
+    "tree_sitter_query": "\n(method_definition\n  name: (property_identifier) @method_name\n  parameters: (formal_parameters) @params\n  return_type: (type_annotation)? @return_type\n  body: (statement_block)? @body\n) @method_def\n",
+    "NAME_NODE": "property_identifier",
+    "SETTER_DECORATOR_ATTR": "set",
+    "PROPERTY_NAME_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "SETTER_ATTR_PATTERN": "set",
+    "METHOD_PATTERN": "set\\s+[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "IDENTIFIER_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "FIRST_PARAM_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*",
+    "RETURN_TYPE_PATTERN": "(?:\\s*:\\s*[\\w.<>\\[\\]|&\\s'\"{}()=>]+)?",
+    "BODY_CAPTURE_LOOKAHEAD": "{[\\s\\S]*"
+  },
+  "decorator": {
+    "tree_sitter_query": "\n(decorator\n   ;; Capture the node right after '@'\n   ;; Usually a 'call_expression' or 'identifier'\n   (_) @decorator_expression\n) @decorator_node\n",
+    "DECORATOR_NODE": "decorator",
+    "DECORATOR_PREFIX": "@",
+    "QUALIFIED_NAME_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*(?:\\.[a-zA-Z_$][a-zA-Z0-9_$]*)*",
+    "ARGS_PATTERN": "(?:\\([^)]*\\))?"
+  },
+  "type_alias": {
+    "tree_sitter_query": "\n(type_alias_declaration\n  name: (type_identifier) @type_name\n  value: (_) @type_value\n) @type_alias_def\n\n(export_statement\n  declaration: (type_alias_declaration\n    name: (type_identifier) @type_name\n    value: (_) @type_value\n  ) @type_alias_def_exported\n)\n",
+    "TYPE_NODE": "type_alias_declaration",
+    "NAME_NODE": "type_identifier",
+    "VALUE_NODE": "_",
+    "TYPE_PATTERN": "(?:export\\s+)?type",
+    "IDENTIFIER_PATTERN": "[a-zA-Z_$][a-zA-Z0-9_$]*"
+  },
+  "enum": {
+    "tree_sitter_query": "\n(enum_declaration\n  name: (identifier) @enum_name\n  body: (enum_body) @enum_body\n) @enum_def\n\n(export_statement\n  declaration: (enum_declaration\n    name: (identifier) @enum_name\n    body: (enum_body) @enum_body\n  ) @enum_def_exported\n)\n",
+    "ENUM_NODE": "enum_declaration",
+    "NAME_NODE": "identifier",
+    "BODY_NODE": "enum_body",
+    "ENUM_PATTERN": "(?:export\\s+)?enum"
+  },
+  "namespace": {
+    "tree_sitter_query": "\n(module\n  name: [\n    (identifier) @namespace_name\n    (string) @namespace_name_string\n  ] @namespace_name_capture\n  body: (module_body | statement_block)? @namespace_body\n) @namespace_def\n\n(export_statement\n  declaration: (module\n    name: [ (identifier) @namespace_name (string) @namespace_name_string ] @namespace_name_capture\n    body: (module_body | statement_block)? @namespace_body\n  ) @namespace_def_exported\n)\n\n(ambient_declaration\n  (module\n     name: [ (identifier) @namespace_name (string) @namespace_name_string ] @namespace_name_capture\n     body: (module_body | statement_block)? @namespace_body\n  )\n) @ambient_namespace_def\n",
+    "NAMESPACE_NODE": "module",
+    "NAME_NODE": "identifier",
+    "BODY_NODE": "module_body",
+    "NAMESPACE_PATTERN": "(?:export\\s+)?(?:namespace|module)"
+  }
+}


### PR DESCRIPTION
## Summary
- add TypeScriptManipulatorBase built on AbstractBlockManipulator
- move TypeScript node patterns into JSON descriptor
- load JSON in TypeScript config
- register TypeScript manipulators on import

## Testing
- `ruff check codehem/languages/lang_typescript/config.py codehem/languages/lang_typescript/manipulator/base.py codehem/languages/lang_typescript/__init__.py`
- `black codehem/languages/lang_typescript/config.py codehem/languages/lang_typescript/manipulator/base.py codehem/languages/lang_typescript/__init__.py`
- `pytest -q`