### PR TITLE
Add roadmap completeness report for sprints 4-7

### DIFF
--- a/ROADMAP_COMPLETENESS.md
+++ b/ROADMAP_COMPLETENESS.md
@@ -1,0 +1,25 @@
+# Roadmap completeness check
+
+This document verifies whether features described for Sprints 4–7 in `ROADMAP.md` appear in the repository and documentation (`README.md`).
+
+## Sprint 4 — DRY: formatter + manipulator
+- **Roadmap scope:** creation of `IndentFormatter`, `BraceFormatter`, and `AbstractBlockManipulator` plus descriptor-based configuration.
+- **Repository evidence:** modules `core/formatting/indent_formatter.py`, `core/formatting/brace_formatter.py` and `core/manipulators/abstract_block_manipulator.py` exist. README mentions subclassing these formatter and manipulator bases【F:README.md†L140-L148】.
+- **Conclusion:** features present – sprint implemented.
+
+## Sprint 5 — Patch API
+- **Roadmap scope:** `get_element_hash`, `apply_patch` with minimal diff and JSON result.
+- **Repository evidence:** `CodeHem.apply_patch` and `get_element_hash` implemented with JSON diff result【F:codehem/main.py†L410-L478】. README lists Patch API among key features【F:README.md†L22-L29】 and shows usage example with `apply_patch` returning JSON【F:README.md†L74-L87】.
+- **Conclusion:** functionality implemented.
+
+## Sprint 6 — Patch API v2 + builder helpers
+- **Roadmap scope:** builder methods for functions/classes/methods, `short_xpath`, return format parameter.
+- **Repository evidence:** `new_function`, `new_class`, `new_method`, and `short_xpath` appear in `CodeHem` class【F:codehem/main.py†L492-L618】. README includes builder helper example【F:README.md†L104-L116】.
+- **Conclusion:** sprint objectives visible.
+
+## Sprint 7 — Workspace & thread-safe writes
+- **Roadmap scope:** workspace index, file locks, parallel safety.
+- **Repository evidence:** `Workspace` class with file-locking in `core/workspace.py`【F:codehem/core/workspace.py†L103-L166】. README provides a workspace usage snippet【F:README.md†L96-L103】.
+- **Conclusion:** sprint completed as described.
+
+Overall, README and code confirm implementation of features for Sprints 4–7 as outlined in `ROADMAP.md`.


### PR DESCRIPTION
## Summary
- verify progress for sprints 4 through 7 using README and ROADMAP
- document findings in `ROADMAP_COMPLETENESS.md`

## Testing
- `pytest -q`