### PR TITLE
Add simple ticket system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ CodeHemError
 * `docs/Developer‑Guide.md` – in‑depth walkthrough of CodeHem API (once Sprint 8 ships).
 * `tests/fixtures/` – curated real‑world code pieces used in regression tests.
 * `ROADMAP.md` (tbd) – living document reflecting sprint progress.
+* `ROADMAP/NextTask.md` – pointer to the next ticket to pick up.
 
 ---
 

--- a/ROADMAP/NextTask.md
+++ b/ROADMAP/NextTask.md
@@ -1,0 +1,2 @@
+The next planned task is **PRD-0001 – Vector-search of elements**.
+This ticket outlines the work required to implement semantic search over the AST.

--- a/ROADMAP/PRD-0001.md
+++ b/ROADMAP/PRD-0001.md
@@ -1,0 +1,12 @@
+# PRD-0001 – Vector-search of elements
+
+**Status:** new
+
+## Task
+Implement vector search over AST elements so that agents can locate code
+semantically using embeddings.
+
+## Definition of Done
+- AST nodes embedded and indexed for quick lookup.
+- CLI exposes `codehem search --query` returning ranked results.
+- Unit tests cover indexing and search API.

--- a/ROADMAP/PRD-0002.md
+++ b/ROADMAP/PRD-0002.md
@@ -1,0 +1,11 @@
+# PRD-0002 – LSIF/LSP streaming
+
+**Status:** new
+
+## Task
+Add LSIF/LSP streaming capabilities for real-time refactoring feedback in editors.
+
+## Definition of Done
+- Streaming API delivers incremental LSIF updates during patches.
+- Documentation includes integration notes for editor plugins.
+- Tests simulate a streaming session and verify protocol compliance.

--- a/ROADMAP/PRD-003.md
+++ b/ROADMAP/PRD-003.md
@@ -1,0 +1,11 @@
+# PRD-003 – VS Code extension
+
+**Status:** new
+
+## Task
+Develop a VS Code extension powered by CodeHem for quick-fixes and rename operations.
+
+## Definition of Done
+- Extension can connect to CodeHem and issue patch commands.
+- Supports highlight of diff results directly in the editor.
+- Marketplace package published with installation instructions.


### PR DESCRIPTION
## Summary
- add `ROADMAP` directory with three ticket files
- include a `NextTask.md` file pointing to the upcoming ticket
- reference `ROADMAP/NextTask.md` from `AGENTS.md`

## Testing
- `pytest -xv`